### PR TITLE
Use entire module path when normalizing module names

### DIFF
--- a/src/amdclean.js
+++ b/src/amdclean.js
@@ -157,7 +157,7 @@
             // -------------------
             //  Returns a normalized module name (removes relative file path urls)
             normalizeModuleName: function(name) {
-                 name = name || '';
+                name = name || '';
                 if(name === '{}') {
                     return name;
                 }


### PR DESCRIPTION
See #17
