### PR TITLE
Fixed processing of reversed AMD conditionals

### DIFF
--- a/src/modules/utils.js
+++ b/src/modules/utils.js
@@ -136,11 +136,20 @@ define([
 				}
 			};
 
+			var reversedMatchObject = {
+				'left': matchObject.right,
+				'right': matchObject.left
+			};
+
 			try {
 				return (_.where(node.test, matchObject).length ||
 					_.where([node.test], matchObject).length ||
 					_.where(node.test.left, matchObject).length ||
-					_.where([node.test.left], matchObject).length);
+					_.where([node.test.left], matchObject).length ||
+					_.where(node.test, reversedMatchObject).length ||
+					_.where([node.test], reversedMatchObject).length ||
+					_.where(node.test.left, reversedMatchObject).length ||
+					_.where([node.test.left], reversedMatchObject).length);
 			} catch(e) {
 				return false;
 			}

--- a/test/specs/convert.js
+++ b/test/specs/convert.js
@@ -703,6 +703,25 @@ describe('amdclean specs', function() {
 				expect(cleanedCode).toBe(standardJavaScript);
 			});
 
+			it('should correctly convert libraries with simple reversed conditional AMD checks', function() {
+				var AMDcode = "(function (root, factory) {" +
+					"'use strict';" +
+					"if ('function' === typeof define) {" +
+					"define('esprima', ['exports'], factory);" +
+					"} else if (typeof exports !== 'undefined') {" +
+					"factory(exports);" +
+					"} else {" +
+					"factory((root.esprima = {}));" +
+					"}" +
+					"}(this, function (exports) {" +
+					"var test = true;" +
+					"}));",
+					cleanedCode = amdclean.clean(AMDcode, defaultOptions),
+					standardJavaScript = "var esprima;(function(root,factory){'use strict';if(true){esprima=function (exports){return typeof factory==='function'?factory(exports):factory;}({});}else if(typeof exports!=='undefined'){factory(exports);}else{factory(root.esprima={});}}(this,function(exports){exports=exports||{};var test=true;return exports;}));";
+
+				expect(cleanedCode).toBe(standardJavaScript);
+			});
+
 		});
 
 	});


### PR DESCRIPTION
Reversed AMD conditionals where not processed correctly:

``` javascript
if ("function" === typeof define) { /*...*/ }
```

Some libraries (like React, for example) unfortunately use this style of conditional AMD support, which renders them unusable with amdclean. This PR fixes this problem by checking for both variants of the comparison.
