### PR TITLE
add extended-javascript-console to "used by" section of readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ A build tool that converts AMD code to standard JavaScript.
 
 * [AddThis Smart Layers](https://www.addthis.com/get/smart-layers) - Third-party social widgets suite
 
+* [Extended JavaScript Console](https://github.com/bignimbus/extended-javascript-console) - Better browser console methods
+
 
 ## Why
 


### PR DESCRIPTION
My library, <a href="https://github.com/bignimbus/extended-javascript-console">Extended JavaScript Console</a>, uses AMDclean to compile modules into production builds.
