### PR TITLE
Fix `startLineNumber` from potentially breaking.

### DIFF
--- a/src/amdclean.js
+++ b/src/amdclean.js
@@ -978,7 +978,19 @@ createAst = function createAst(providedCode) {
 };
 convertDefinesAndRequires = function convertDefinesAndRequires(node, parent) {
   var amdclean = this, options = amdclean.options, moduleName, args, dependencies, moduleReturnValue, moduleId, params, isDefine = utils.isDefine(node), isRequire = utils.isRequire(node), startLineNumber, callbackFuncArg = false, type = '', shouldBeIgnored, moduleToBeIgnored, parentHasFunctionExpressionArgument, defaultRange = defaultValues.defaultRange, defaultLOC = defaultValues.defaultLOC, range = node.range || defaultRange, loc = node.loc || defaultLOC, dependencyBlacklist = defaultValues.dependencyBlacklist, shouldOptimize;
-  startLineNumber = isDefine || isRequire ? node.expression.loc.start.line : node && node.loc && node.loc.start ? node.loc.start.line : null;
+  startLineNumber = isDefine || isRequire ? (
+    node && node.expression && node.expression.loc && node.expression.loc.start && node.expression.loc.start.line ? (
+      node.expression.loc.start.line
+    ) : (
+      null
+    )
+  ) : (
+    node && node.loc && node.loc.start ? (
+      node.loc.start.line
+    ) : (
+      null
+    )
+  );
   shouldBeIgnored = amdclean.matchingCommentLineNumbers[startLineNumber] || amdclean.matchingCommentLineNumbers[startLineNumber - 1];
   // If it is an AMD conditional statement
   // e.g. if(typeof define === 'function') {}


### PR DESCRIPTION
When trying to clean my code I run into the following error:

> TypeError: Cannot read property 'start' of undefined
>     at Object.convertDefinesAndRequires ($PWD/node_modules/amdclean/src/amdclean.js:981:64)
>     at Controller.estraverse.replace.enter ($PWD/node_modules/amdclean/src/amdclean.js:1218:40)
>     at Controller.__execute ($PWD/node_modules/estraverse/estraverse.js:399:31)
>     at Controller.replace ($PWD/node_modules/estraverse/estraverse.js:633:27)
>     at Object.replace ($PWD/node_modules/estraverse/estraverse.js:714:27)
>     at Object.traverseAndUpdateAst ($PWD/node_modules/amdclean/src/amdclean.js:1197:14)
>     at Object.clean ($PWD/node_modules/amdclean/src/amdclean.js:1271:30)
>     at publicAPI.clean ($PWD/node_modules/amdclean/src/amdclean.js:1667:91)
>     at DestroyableTransform._transform ($PWD/index.js:39:26)
>     at DestroyableTransform.Transform._read ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:159:10)
>     at DestroyableTransform.Transform._write ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_transform.js:147:83)
>     at doWrite ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:313:64)
>     at writeOrBuffer ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:302:5)
>     at DestroyableTransform.Writable.write ($PWD/node_modules/through2/node_modules/readable-stream/lib/_stream_writable.js:241:11)
>     at CompileStream.ondata (_stream_readable.js:528:20)
>     at emitOne (events.js:77:13)

I found by hardening the check of `convertDefinesAndRequires` with the
code in this PR prevents this error from being thrown.
